### PR TITLE
Update bitmap font check

### DIFF
--- a/src/elements/BitmapTextContainer.js
+++ b/src/elements/BitmapTextContainer.js
@@ -80,7 +80,7 @@ export default class BitmapTextContainer extends PIXI.Container {
   measureText (result = new PIXI.Point(), width = this._width) {
 
     if (!this._fontData) {
-      this._fontData = PIXI.BitmapText.fonts[this._font];
+      this._fontData = PIXI.BitmapFont.available[this._font];
     }
 
     if (!this._fontData || !this._text) {
@@ -216,7 +216,7 @@ export default class BitmapTextContainer extends PIXI.Container {
   }
 
   validate () {
-    this._fontData = PIXI.BitmapText.fonts[this._font];
+    this._fontData = PIXI.BitmapFont.available[this._font];
 
     if (!this._fontData) {
       return;

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import React from 'react';
 import ReactFiberReconciler from 'react-reconciler';
 
 import BaseElement from './elements/BaseElement';
-import BackgroundContainerElement from './elements/BackgroundContainer';
+import BackgroundContainerElement, { RESIZE_MODES as RPL_RESIZE_MODES } from './elements/BackgroundContainer';
 import BackgroundImageElement from './elements/BackgroundImage';
 import BitmapTextElement from './elements/BitmapText';
 import ContainerElement from './elements/Container';
@@ -166,6 +166,8 @@ export const NineSliceSprite = 'NineSliceSprite';
 export const Graphics = 'Graphics';
 export const Rectangle = 'Rectangle';
 export const MaskContainer = 'MaskContainer';
+
+export const RESIZE_MODES = RPL_RESIZE_MODES;
 
 registerElement(Container, ContainerElement);
 registerElement(Text, TextElement);


### PR DESCRIPTION
`PIXI.BitmapText.fonts` has been deprecated in Pixi 5.3